### PR TITLE
fix memory leak

### DIFF
--- a/lycoris.py
+++ b/lycoris.py
@@ -653,8 +653,6 @@ def lyco_apply_weights(self: Union[torch.nn.Conv2d, torch.nn.Linear, torch.nn.Mu
         return
   
     lyco_layer_name = getattr(self, 'lyco_layer_name', None)
-    if lyco_layer_name is None:
-        return
 
     current_names = getattr(self, "lyco_current_names", ())
     lora_prev_names = getattr(self, "lora_prev_names", ())
@@ -677,6 +675,8 @@ def lyco_apply_weights(self: Union[torch.nn.Conv2d, torch.nn.Linear, torch.nn.Mu
         # print('lyco remove weight')
         self.lyco_weights_backup = None
         lora_weights_backup = None
+    elif lyco_layer_name is None:
+        self.lyco_weights_backup = None
 
     if current_names != wanted_names or lora_prev_names != lora_names:
         if weights_backup is not None and lora_names == lora_prev_names:

--- a/lycoris.py
+++ b/lycoris.py
@@ -648,11 +648,10 @@ def lyco_apply_weights(self: Union[torch.nn.Conv2d, torch.nn.Linear, torch.nn.Mu
     If weights already have this particular set of lycos applied, does nothing.
     If not, restores orginal weights from backup and alters weights according to lycos.
     """
-
-    if len(loaded_lycos) == 0:
-        return
-  
+    
     lyco_layer_name = getattr(self, 'lyco_layer_name', None)
+    if lyco_layer_name is None:
+        return
 
     current_names = getattr(self, "lyco_current_names", ())
     lora_prev_names = getattr(self, "lora_prev_names", ())
@@ -675,7 +674,7 @@ def lyco_apply_weights(self: Union[torch.nn.Conv2d, torch.nn.Linear, torch.nn.Mu
         # print('lyco remove weight')
         self.lyco_weights_backup = None
         lora_weights_backup = None
-    elif lyco_layer_name is None:
+    elif len(loaded_lycos) == 0:
         self.lyco_weights_backup = None
 
     if current_names != wanted_names or lora_prev_names != lora_names:

--- a/lycoris.py
+++ b/lycoris.py
@@ -649,6 +649,9 @@ def lyco_apply_weights(self: Union[torch.nn.Conv2d, torch.nn.Linear, torch.nn.Mu
     If not, restores orginal weights from backup and alters weights according to lycos.
     """
 
+    if len(loaded_lycos) == 0:
+        return
+  
     lyco_layer_name = getattr(self, 'lyco_layer_name', None)
     if lyco_layer_name is None:
         return


### PR DESCRIPTION
if lyco is NOT used, it will still try to allocate memory due to `self.lyco_weights_backup = weights_backup`, but those are then never released as there is no lyco applied.

fix is simple early-exit if no lyco model is loaded.

memray before patch shows (must run on cpu so memray can capture memory allocations):
> 390.238MB (0.71 %) lyco_apply_weights  extensions/a1111-sd-webui-lycoris/lycoris.py:671
