### PR TITLE
Detect if inpainting model and zero pad updown to match

### DIFF
--- a/lycoris.py
+++ b/lycoris.py
@@ -695,7 +695,11 @@ def lyco_apply_weights(self: Union[torch.nn.Conv2d, torch.nn.Linear, torch.nn.Mu
             )
             if module is not None and hasattr(self, 'weight'):
                 # print(lyco_layer_name, multiplier)
-                self.weight += lyco_calc_updown(lyco, module, self.weight) * multiplier
+                updown = lyco_calc_updown(lyco, module, self.weight)
+                if len(self.weight.shape) == 4 and self.weight.shape[1] == 9:
+                    # inpainting model. zero pad updown to make channel[1]  4 to 9
+                    updown = F.pad(updown, (0, 0, 0, 0, 0, 5))
+                self.weight += updown * multiplier
                 continue
 
             module_q = lyco.modules.get(lyco_layer_name + "_q_proj", None)


### PR DESCRIPTION
Zero pad the additional dimensions on inpainting model if it is detected. Tested quite a bit and it seems to work great. Including 2 examples using same seeds/prompt on both RealisticVision 2.0 and the RealisticVision 2.0 inpainting model and malcolmrey's locon_keanu_v1_from_v1_64_32

![00012-42](https://github.com/KohakuBlueleaf/a1111-sd-webui-lycoris/assets/195960/3531850f-a0fa-4bfb-9584-3f98c5944db9)
*RealisticVision 2.0 - sks person <lyco:locon_keanu_v1_from_v1_64_32:1.0>*

![00011-42](https://github.com/KohakuBlueleaf/a1111-sd-webui-lycoris/assets/195960/a39c7f07-1339-4263-ae87-86117fdfdb74)
*RealisticVision 2.0-inpainting - sks person <lyco:locon_keanu_v1_from_v1_64_32:1.0>*

![00017-42](https://github.com/KohakuBlueleaf/a1111-sd-webui-lycoris/assets/195960/a1676677-c703-42e9-9322-c451843522ff)
*RealisticVision 2.0 - sks person <lyco:locon_keanu_v1_from_v1_64_32:1.0>*

![00016-42](https://github.com/KohakuBlueleaf/a1111-sd-webui-lycoris/assets/195960/67ccf7b9-09b6-4d11-a180-49718fe7448d)
*RealisticVision 2.0-inpainting - sks person <lyco:locon_keanu_v1_from_v1_64_32:1.0>*


Solves https://github.com/KohakuBlueleaf/a1111-sd-webui-lycoris/issues/39 