### PR TITLE
Fix type check for forge

### DIFF
--- a/l_network_lora.py
+++ b/l_network_lora.py
@@ -29,8 +29,8 @@ class NetworkModuleLora(network.NetworkModule):
         if weight is None and none_ok:
             return None
 
-        is_linear = type(self.sd_module) in [torch.nn.Linear, torch.nn.modules.linear.NonDynamicallyQuantizableLinear, torch.nn.MultiheadAttention]
-        is_conv = type(self.sd_module) in [torch.nn.Conv2d]
+        is_linear = isinstance(self.sd_module, (torch.nn.Linear, torch.nn.modules.linear.NonDynamicallyQuantizableLinear, torch.nn.MultiheadAttention))
+        is_conv = isinstance(self.sd_module, (torch.nn.Conv2d))
 
         if is_linear:
             weight = weight.reshape(weight.shape[0], -1)

--- a/l_network_oft.py
+++ b/l_network_oft.py
@@ -38,7 +38,7 @@ class NetworkModuleOFT(network.NetworkModule):
 
         is_linear = isinstance(self.sd_module, (torch.nn.Linear, torch.nn.modules.linear.NonDynamicallyQuantizableLinear))
         is_conv = isinstance(self.sd_module, (torch.nn.Conv2d))
-        is_other_linear = isinstance(self.sd_module, [torch.nn.MultiheadAttention) # unsupported
+        is_other_linear = isinstance(self.sd_module, (torch.nn.MultiheadAttention)) # unsupported
 
         if is_linear:
             self.out_dim = self.sd_module.out_features

--- a/l_network_oft.py
+++ b/l_network_oft.py
@@ -36,9 +36,9 @@ class NetworkModuleOFT(network.NetworkModule):
             # self.alpha is unused
             self.dim = self.oft_blocks.shape[1] # (num_blocks, block_size, block_size)
 
-        is_linear = type(self.sd_module) in [torch.nn.Linear, torch.nn.modules.linear.NonDynamicallyQuantizableLinear]
-        is_conv = type(self.sd_module) in [torch.nn.Conv2d]
-        is_other_linear = type(self.sd_module) in [torch.nn.MultiheadAttention] # unsupported
+        is_linear = isinstance(self.sd_module, (torch.nn.Linear, torch.nn.modules.linear.NonDynamicallyQuantizableLinear))
+        is_conv = isinstance(self.sd_module, (torch.nn.Conv2d))
+        is_other_linear = isinstance(self.sd_module, [torch.nn.MultiheadAttention) # unsupported
 
         if is_linear:
             self.out_dim = self.sd_module.out_features


### PR DESCRIPTION
All nn modules in forge are a derived class from its original one, so we must write code like this to support old webui and forge at the same time.

See https://github.com/lllyasviel/stable-diffusion-webui-forge/blob/main/ldm_patched/modules/ops.py#L32